### PR TITLE
Remove GitHub auth from agent steps to mitigate prompt injection

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Construct Prompt
         id: prompt
         uses: actions/github-script@v7
@@ -90,12 +92,11 @@ jobs:
             2.  **Fix**: Implement the changes necessary to resolve the issue.
             3.  **Verify**: Ensure the code is correct and follows existing patterns.
             4.  **Output**: Do not output the diff. Provide a brief summary of what you changed.
+            5.  **Safety**: Do not run \`gh\` commands or call the GitHub API directly. This workflow applies GitHub writes in trusted post-processing steps.
             `;
             core.setOutput('prompt', prompt);
       - name: Run Oz Agent
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -128,6 +129,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "Fix for Issue #$ISSUE_NUMBER"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH_NAME" --force
 
           # Create PR

--- a/.github/workflows/daily-issue-summary.yml
+++ b/.github/workflows/daily-issue-summary.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Fetch Issues
         id: fetch_issues
         env:
@@ -119,8 +121,6 @@ jobs:
       - name: Run Oz Agent
         if: steps.fetch_issues.outputs.has_issues == 'true'
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}

--- a/.github/workflows/fix-failing-checks.yml
+++ b/.github/workflows/fix-failing-checks.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Get Failure Logs
         id: logs
         env:
@@ -132,8 +133,6 @@ jobs:
             core.setOutput('prompt', prompt);
       - name: Run Oz Agent
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -177,6 +176,7 @@ jobs:
           git checkout -b "$FIX_BRANCH"
           git add .
           git commit -m "Fix failing checks for run $RUN_ID"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$FIX_BRANCH" --force
 
           # Find associated PR

--- a/.github/workflows/respond-to-comment.yml
+++ b/.github/workflows/respond-to-comment.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Acknowledge Comment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -154,13 +156,12 @@ jobs:
             6. Format your response in Markdown.
             7. Your output will be posted as a reply to the user.
             8. Do not attempt to stage or commit changes. This happens automatically after you complete your response.
+            9. Do not run \`gh\` commands or call the GitHub API directly. This workflow handles GitHub writes in trusted post-processing steps.
             `;
 
             core.setOutput('prompt', prompt);
       - name: Run Oz Agent
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -181,6 +182,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git commit -m "Oz Agent: Address comment"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
             git push
           else
             echo "No changes to commit."

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -38,10 +38,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Checkout PR
         env:
           GH_TOKEN: ${{ github.token }}
@@ -257,8 +258,6 @@ jobs:
             core.setOutput('prompt', prompt);
       - name: Run Oz Agent Review
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}

--- a/.github/workflows/suggest-review-fixes.yml
+++ b/.github/workflows/suggest-review-fixes.yml
@@ -38,10 +38,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Fetch review comments
         uses: actions/github-script@v7
         with:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Each scenario is provided in three forms:
   and calls the reusable workflow via `jobs.<id>.uses`. These templates are intended to be copied
   into `.github/workflows/` in your own repository and customized.
 
+Security note: in these examples, the Oz Agent step is intentionally run without direct GitHub
+authentication, and all GitHub write operations are handled in explicit post-processing steps. This
+reduces prompt-injection blast radius while preserving automation.
+
 ### How to use the scenario workflows
 
 1. Pick a scenario below (e.g., Respond to Comment, Auto Fix Issue).
@@ -137,7 +141,7 @@ _Consumer Template_: [consumer-workflows/review-pr.yml](consumer-workflows/revie
 **Setup:**
 
 - Ensure `WARP_API_KEY` is set in Repository Secrets.
-- The Agent needs read access to contents and write access to pull-requests.
+- Workflow requires read access to contents and write access to pull-requests.
 
 **Expected Output:**
 
@@ -230,7 +234,7 @@ style), the Agent replies with a code suggestion block containing the fix.
 **Setup:**
 
 - Ensure `WARP_API_KEY` is set in Repository Secrets.
-- Action requires write permissions for `contents` and `pull-requests`.
+- Workflow requires `contents: read` and `pull-requests: write`.
 
 **Expected Output:**
 

--- a/consumer-workflows/review-pr.yml
+++ b/consumer-workflows/review-pr.yml
@@ -12,7 +12,7 @@
 #
 # Setup:
 #   - Ensure WARP_API_KEY is set in Repository Secrets.
-#   - The Agent needs read access to contents and write access to pull-requests.
+#   - Workflow requires read access to contents and write access to pull-requests.
 #
 # Expected Output:
 #   - Inline comments on the PR diff highlighting potential bugs, security issues, or style improvements.

--- a/examples/auto-fix-issue.yml
+++ b/examples/auto-fix-issue.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Construct Prompt
         id: prompt
@@ -83,13 +85,12 @@ jobs:
             2.  **Fix**: Implement the changes necessary to resolve the issue.
             3.  **Verify**: Ensure the code is correct and follows existing patterns.
             4.  **Output**: Do not output the diff. Provide a brief summary of what you changed.
+            5.  **Safety**: Do not run \`gh\` commands or call the GitHub API directly. This workflow applies GitHub writes in trusted post-processing steps.
             `;
             core.setOutput('prompt', prompt);
 
       - name: Run Oz Agent
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -120,6 +121,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "Fix for Issue #$ISSUE_NUMBER"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH_NAME" --force
 
           # Create PR

--- a/examples/daily-issue-summary.yml
+++ b/examples/daily-issue-summary.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Fetch Issues
         id: fetch_issues
@@ -111,8 +113,6 @@ jobs:
       - name: Run Oz Agent
         if: steps.fetch_issues.outputs.has_issues == 'true'
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}

--- a/examples/fix-failing-checks.yml
+++ b/examples/fix-failing-checks.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get Failure Logs
         id: logs
@@ -129,8 +130,6 @@ jobs:
 
       - name: Run Oz Agent
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -172,6 +171,7 @@ jobs:
           git checkout -b "$FIX_BRANCH"
           git add .
           git commit -m "Fix failing checks for run $RUN_ID"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$FIX_BRANCH" --force
 
           # Find associated PR

--- a/examples/respond-to-comment.yml
+++ b/examples/respond-to-comment.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Acknowledge Comment
         env:
@@ -148,14 +150,13 @@ jobs:
             6. Format your response in Markdown.
             7. Your output will be posted as a reply to the user.
             8. Do not attempt to stage or commit changes. This happens automatically after you complete your response.
+            9. Do not run \`gh\` commands or call the GitHub API directly. This workflow handles GitHub writes in trusted post-processing steps.
             `;
 
             core.setOutput('prompt', prompt);
 
       - name: Run Oz Agent
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         id: agent
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
@@ -174,6 +175,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add .
             git commit -m "Oz Agent: Address comment"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
             git push
           else
             echo "No changes to commit."

--- a/examples/review-pr.yml
+++ b/examples/review-pr.yml
@@ -7,7 +7,7 @@
 #
 # Setup:
 #   - Ensure WARP_API_KEY is set in Repository Secrets.
-#   - The Agent needs read access to contents and write access to pull-requests.
+#   - Workflow requires read access to contents and write access to pull-requests.
 #
 # Expected Output:
 #   - Inline comments on the PR diff highlighting potential bugs, security issues, or style improvements.
@@ -28,10 +28,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout PR
         env:
@@ -250,8 +251,6 @@ jobs:
 
       - name: Run Oz Agent Review
         uses: warpdotdev/oz-agent-action@v1
-        env:
-          GH_TOKEN: ${{ github.token }}
         with:
           prompt: ${{ steps.prompt.outputs.prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}

--- a/examples/suggest-review-fixes.yml
+++ b/examples/suggest-review-fixes.yml
@@ -25,10 +25,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Fetch review comments
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

A maintainer adapting our example workflows for [Vite](https://github.com/vitejs/vite/pull/21767) identified that passing `issues: write` (or any write-scoped token) directly to the Oz Agent step exposes a prompt-injection attack surface: a malicious issue body or comment could instruct the agent to delete issues, remove comments, or abuse any permission granted by the token.

This PR hardens example workflows so the agent step never has access to GitHub credentials, and write operations are handled in post-processing action steps.

## Changes

**Across all 6 example workflows (`examples/`):**
- Added `persist-credentials: false` to all `actions/checkout` steps so the `GITHUB_TOKEN` is not stored in the local git config where the agent could access it. This is needed because credentials are shared across the job, and need to be manually applied at each step to avoid splitting examples across multiple jobs (see Alternatives Considered).
- Removed `GH_TOKEN` / `env` from all `warpdotdev/oz-agent-action` steps. This does hurt the simplicity of our examples by blocking agent writes, so I'm open to discussion here.
- For workflows that push commits (`respond-to-comment`, `auto-fix-issue`, `fix-failing-checks`): added just-in-time `git remote set-url` with `GH_TOKEN` in the trusted `commit-and-push` step. 
- Added prompt-level instructions telling the agent not to run `gh` commands or call the GitHub API directly.

**Permission tightening:**
- `review-pr`: removed unnecessary `issues: write` (only needs `pull-requests: write`).
- `suggest-review-fixes`: removed unnecessary `issues: write`.

**Documentation:**
- Added a security note to `README.md` explaining the tokenless-agent pattern.
- Updated setup text to reflect accurate permission requirements.
- 
## Alternative considered: separate jobs (Vite's approach)

[Vite's PR](https://github.com/vitejs/vite/pull/21767) solves this by splitting workflows into two jobs: a read-only job that runs the agent, and a write-capable job that consumes the agent's output via job `outputs`. Because jobs run on separate VMs, the write token never exists in the agent's environment.

We chose not to adopt this approach here because:
- Several of our examples (`auto-fix-issue`, `respond-to-comment`, `fix-failing-checks`) have the agent **modify files** that then get committed. Transferring a dirty working tree across jobs requires `actions/upload-artifact` / `actions/download-artifact`, adding complexity and latency that's inappropriate for example workflows meant to be simple and copy-pasteable.
- For our read-only analysis workflows (`review-pr`, `suggest-review-fixes`, `daily-issue-summary`), the two-job split would be strictly better and is worth considering as a follow-up.

Stripping credentials from the agent's environment within a single job is a middle ground here.
