### PR TITLE
Fetch PR comments and provide them as context for review workflow

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -14,8 +14,23 @@ Review the current pull request and write the output to `review.json`.
 - The working directory is the PR branch checkout.
 - The workflow provides an annotated diff in `pr_diff.txt`.
 - The workflow provides the PR description in `pr_description.txt`.
+- The workflow provides existing PR comments (if any) in `pr_comments.txt`.
 - Focus on files and lines changed by this PR.
 - Do not post comments or reviews to GitHub directly.
+
+## Existing PR Comments
+
+Before writing your review, read `pr_comments.txt`. Use these comments to:
+
+- Understand design decisions explained by the author or other reviewers.
+- Incorporate context from prior review feedback into your analysis.
+- Avoid repeating points already raised. If an existing comment covers a concern you would raise,
+  skip it. You may add a clarification comment if the existing comment does not fully express your
+  concern.
+- If you disagree with an existing comment, you may note it in the summary but do not leave a
+  duplicate inline comment.
+
+The `pr_comments.txt` file will only exist if there were existing comments on the PR.
 
 ## Review Scope
 

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -95,11 +95,55 @@ jobs:
             const descriptionPath = path.resolve('pr_description.txt');
             fs.writeFileSync(descriptionPath, pr.body || 'No description provided.', 'utf8');
 
+            // Fetch existing PR comments (both issue-level and inline review comments).
+            const commentsPath = path.resolve('pr_comments.txt');
+            const commentSections = [];
+
+            // 1. PR-level (issue) comments.
+            const issueComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber }
+            );
+            if (issueComments.length > 0) {
+              commentSections.push('## PR-level comments\n');
+              for (const c of issueComments) {
+                commentSections.push(`### Comment by @${c.user.login} (${c.created_at})`);
+                commentSections.push(c.body || '');
+                commentSections.push('');
+              }
+            }
+
+            // 2. Inline review comments.
+            const reviewComments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              { owner, repo, pull_number: prNumber }
+            );
+            if (reviewComments.length > 0) {
+              commentSections.push('## Inline review comments\n');
+              for (const c of reviewComments) {
+                commentSections.push(`### Comment by @${c.user.login} on ${c.path}${c.line ? `:${c.line}` : ''} (${c.created_at})`);
+                if (c.diff_hunk) {
+                  commentSections.push('```diff');
+                  commentSections.push(c.diff_hunk);
+                  commentSections.push('```');
+                }
+                commentSections.push(c.body || '');
+                commentSections.push('');
+              }
+            }
+
+            if (commentSections.length > 0) {
+              fs.writeFileSync(commentsPath, commentSections.join('\n'), 'utf8');
+            } else {
+              fs.writeFileSync(commentsPath, 'No existing comments on this PR.', 'utf8');
+            }
+
             const prompt = `Review Pull Request #${prNumber}.
 
             PR title: ${pr.title}
             PR description: Read \`${descriptionPath}\`
             Annotated diff: Read \`${diffPath}\`
+            Existing PR comments: Read \`${commentsPath}\`
 
             Use the review skill instructions as the base behavior. Apply them to this PR only.`;
 

--- a/examples/review-pr.yml
+++ b/examples/review-pr.yml
@@ -82,11 +82,55 @@ jobs:
             const descriptionPath = path.resolve('pr_description.txt');
             fs.writeFileSync(descriptionPath, pr.body || 'No description provided.', 'utf8');
 
+            // Fetch existing PR comments (both issue-level and inline review comments).
+            const commentsPath = path.resolve('pr_comments.txt');
+            const commentSections = [];
+
+            // 1. PR-level (issue) comments.
+            const issueComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber }
+            );
+            if (issueComments.length > 0) {
+              commentSections.push('## PR-level comments\n');
+              for (const c of issueComments) {
+                commentSections.push(`### Comment by @${c.user.login} (${c.created_at})`);
+                commentSections.push(c.body || '');
+                commentSections.push('');
+              }
+            }
+
+            // 2. Inline review comments.
+            const reviewComments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              { owner, repo, pull_number: prNumber }
+            );
+            if (reviewComments.length > 0) {
+              commentSections.push('## Inline review comments\n');
+              for (const c of reviewComments) {
+                commentSections.push(`### Comment by @${c.user.login} on ${c.path}${c.line ? `:${c.line}` : ''} (${c.created_at})`);
+                if (c.diff_hunk) {
+                  commentSections.push('```diff');
+                  commentSections.push(c.diff_hunk);
+                  commentSections.push('```');
+                }
+                commentSections.push(c.body || '');
+                commentSections.push('');
+              }
+            }
+
+            if (commentSections.length > 0) {
+              fs.writeFileSync(commentsPath, commentSections.join('\n'), 'utf8');
+            } else {
+              fs.writeFileSync(commentsPath, 'No existing comments on this PR.', 'utf8');
+            }
+
             const prompt = `Review Pull Request #${prNumber}.
 
             PR title: ${pr.title}
             PR description: Read \`${descriptionPath}\`
             Annotated diff: Read \`${diffPath}\`
+            Existing PR comments: Read \`${commentsPath}\`
 
             Use the review skill instructions as the base behavior. Apply them to this PR only.`;
 


### PR DESCRIPTION
## Summary

The review-pr workflow currently provides the PR description and diff as context to the agent, but does not include existing comments on the PR. This means the agent can't consider design decisions explained in comments, feedback from other reviewers, or avoid repeating points that have already been raised.

## Changes

### Workflow (`examples/review-pr.yml` + generated files)
- Added comment fetching in the "Construct Review Prompt" step using the GitHub API:
  - **PR-level comments** via `issues.listComments` (general discussion comments)
  - **Inline review comments** via `pulls.listReviewComments` (line-attached review comments with diff hunks)
- Comments are written to `pr_comments.txt` in a human-readable format with author, timestamp, file/line info, and diff context
- The prompt now references `pr_comments.txt` alongside the existing `pr_diff.txt` and `pr_description.txt`
- Both paginated APIs are used to ensure all comments are fetched

### Skill (`.agents/skills/review-pr/SKILL.md`)
- Added `pr_comments.txt` to the Context section
- Added new "Existing PR Comments" section instructing the agent to:
  - Understand design decisions from the author or reviewers
  - Incorporate prior feedback into the analysis
  - Skip concerns already raised by existing comments
  - Note disagreements in the summary rather than duplicating inline comments

_Conversation: https://staging.warp.dev/conversation/981d107f-cf44-4bff-91f6-0c7c921f0a11_

_This PR was generated with [Oz](https://warp.dev/oz)._
