### PR TITLE
Log GitHub API error details when posting PR review fails

### DIFF
--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -303,6 +303,12 @@ jobs:
               console.log('Review posted successfully.');
 
             } catch (error) {
+              if (error.response?.data?.errors) {
+                console.error('GitHub API error details:', JSON.stringify(error.response.data.errors, null, 2));
+              }
+              if (error.response?.data) {
+                console.error('GitHub API response data:', JSON.stringify(error.response.data, null, 2));
+              }
               console.error('Failed to post review:', error);
               core.setFailed(`Failed to post review: ${error.message}`);
             }

--- a/examples/review-pr.yml
+++ b/examples/review-pr.yml
@@ -289,6 +289,12 @@ jobs:
               console.log('Review posted successfully.');
 
             } catch (error) {
+              if (error.response?.data?.errors) {
+                console.error('GitHub API error details:', JSON.stringify(error.response.data.errors, null, 2));
+              }
+              if (error.response?.data) {
+                console.error('GitHub API response data:', JSON.stringify(error.response.data, null, 2));
+              }
               console.error('Failed to post review:', error);
               core.setFailed(`Failed to post review: ${error.message}`);
             }


### PR DESCRIPTION
## Summary

When the GitHub API returns a 422 error (e.g. "Line could not be resolved") while posting a PR review, the current error handling only logs the generic error message. This makes it difficult to diagnose which specific comments had invalid line numbers.

This change adds detailed error logging to the `Post Review` step's catch block in the review-pr workflow:
- Logs `error.response.data.errors` (the array of specific validation errors from GitHub)
- Logs the full `error.response.data` object

This will make it much easier to debug issues like REMOTE-1115 where comments reference lines that can't be resolved in the PR diff.

## Changes
- `examples/review-pr.yml` — Added detailed GitHub API error logging in the catch block
- `.github/workflows/review-pr.yml` — Regenerated from the example

_Conversation: https://staging.warp.dev/conversation/e0d991b8-39dd-4d78-85e3-c621fc1fcd2a_
_Run: https://oz.staging.warp.dev/runs/e3f0715f-e937-4b02-a7c4-dfa07927508f_

_This PR was generated with [Oz](https://warp.dev/oz)._
