### PR TITLE
Support binary files in PR review workflow

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -38,9 +38,23 @@ The `pr_comments.txt` file will only exist if there were existing comments on th
 - Include style or nit comments only when you can provide a concrete suggestion block.
 - If a concern involves untouched code, mention it in the summary instead of an inline comment.
 
+## Binary Files
+
+Binary files (images, compiled assets, etc.) appear in the diff as:
+
+```
+diff --git a/path/to/file b/path/to/file
+Binary files /dev/null and b/path/to/file differ
+```
+
+They have no line annotations. Comments on binary files must:
+
+- Include only `path` and `body`. Do not include `line`, `start_line`, or `side`.
+- Not include suggestion blocks (there is no source text to replace).
+
 ## Diff Line Annotations
 
-The diff file uses these prefixes:
+The diff file uses these prefixes for text files:
 
 - `[OLD:n]` for deleted lines on the old side. Use `"LEFT"`.
 - `[NEW:n]` for added lines on the new side. Use `"RIGHT"`.
@@ -91,6 +105,10 @@ Create `review.json` with this shape:
       "side": "RIGHT",
       "start_line": 40,
       "body": "⚠️ [IMPORTANT] Short explanation\n\n```suggestion\nreplacement\n```"
+    },
+    {
+      "path": "assets/logo.png",
+      "body": "💡 [SUGGESTION] Consider compressing this image to reduce bundle size."
     }
   ]
 }
@@ -99,9 +117,10 @@ Create `review.json` with this shape:
 Field rules:
 
 - `path` must be relative to the repository root.
-- `line` is required and must target the correct side.
-- `start_line` is optional and only for multi-line ranges.
-- `side` must be `"LEFT"` or `"RIGHT"`.
+- For text files: `line` is required and must target the correct side. `side` must be `"LEFT"` or
+  `"RIGHT"`. `start_line` is optional and only for multi-line ranges.
+- For binary files: `line`, `start_line`, and `side` must be omitted. Only `path` and `body` are
+  allowed.
 
 ## Summary Requirements
 

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -60,6 +60,7 @@ jobs:
             /^index / { print; next }
             /^---/ { print; next }
             /^\+\+\+/ { print; next }
+            /^Binary files / { print; next }
             /^@@/ {
               # Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
               split($2, old_parts, ",")
@@ -213,7 +214,13 @@ jobs:
               );
               const validPaths = new Set(prFiles.map(f => f.filename));
 
+              // Binary files lack a patch property in the listFiles response.
+              const patchlessPaths = new Set(
+                prFiles.filter(f => !f.patch).map(f => f.filename)
+              );
+
               const comments = [];
+              const fileComments = [];
 
               for (const c of rawComments) {
                 if (!c || typeof c !== 'object') continue;
@@ -230,6 +237,25 @@ jobs:
                   continue;
                 }
 
+                const isBinary = patchlessPaths.has(normalizedPath);
+
+                if (isBinary) {
+                  // Binary files cannot have line-level comments; ignore any line info.
+                  if (c.line !== undefined && c.line !== null) {
+                    console.log(`Ignoring line number on binary file comment: ${normalizedPath}`);
+                  }
+                  if (c.start_line !== undefined && c.start_line !== null) {
+                    console.log(`Ignoring start_line on binary file comment: ${normalizedPath}`);
+                  }
+
+                  fileComments.push({
+                    path: normalizedPath,
+                    body: decodeNewlines(c.body),
+                  });
+                  continue;
+                }
+
+                // Text file: line is required.
                 const line = Number(c.line);
                 if (!Number.isInteger(line) || line <= 0) {
                   console.log('Skipping comment with invalid line:', c);
@@ -276,31 +302,52 @@ jobs:
 
               const hasSummary = summary.length > 0;
 
-              if (!hasSummary && comments.length === 0) {
+              if (!hasSummary && comments.length === 0 && fileComments.length === 0) {
                 console.log('No valid summary or inline comments found. Skipping review posting.');
                 return;
               }
 
-              const payload = {
-                owner,
-                repo,
-                pull_number: prNumber,
-                event: 'COMMENT',
-              };
+              // Post the main review with text-file inline comments.
+              if (hasSummary || comments.length > 0) {
+                const payload = {
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  event: 'COMMENT',
+                };
 
-              if (hasSummary) {
-                payload.body = summary;
-              } else {
-                payload.body = 'Automated review by Oz Agent';
+                if (hasSummary) {
+                  payload.body = summary;
+                } else {
+                  payload.body = 'Automated review by Oz Agent';
+                }
+
+                if (comments.length > 0) {
+                  payload.comments = comments;
+                }
+
+                await github.rest.pulls.createReview(payload);
+                console.log('Review posted successfully.');
               }
 
-              if (comments.length > 0) {
-                payload.comments = comments;
+              // Post binary-file comments separately as file-level review comments.
+              const commitId = context.payload.pull_request.head.sha;
+              for (const bc of fileComments) {
+                try {
+                  await github.rest.pulls.createReviewComment({
+                    owner,
+                    repo,
+                    pull_number: prNumber,
+                    commit_id: commitId,
+                    path: bc.path,
+                    body: bc.body,
+                    subject_type: 'file',
+                  });
+                  console.log(`Posted binary file comment on ${bc.path}`);
+                } catch (commentError) {
+                  console.error(`Failed to post binary file comment on ${bc.path}:`, commentError.message);
+                }
               }
-
-              await github.rest.pulls.createReview(payload);
-
-              console.log('Review posted successfully.');
 
             } catch (error) {
               console.error('Failed to post review:', error);

--- a/examples/review-pr.yml
+++ b/examples/review-pr.yml
@@ -46,6 +46,7 @@ jobs:
             /^index / { print; next }
             /^---/ { print; next }
             /^\+\+\+/ { print; next }
+            /^Binary files / { print; next }
             /^@@/ {
               # Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
               split($2, old_parts, ",")
@@ -199,7 +200,13 @@ jobs:
               );
               const validPaths = new Set(prFiles.map(f => f.filename));
 
+              // Binary files lack a patch property in the listFiles response.
+              const patchlessPaths = new Set(
+                prFiles.filter(f => !f.patch).map(f => f.filename)
+              );
+
               const comments = [];
+              const fileComments = [];
 
               for (const c of rawComments) {
                 if (!c || typeof c !== 'object') continue;
@@ -216,6 +223,25 @@ jobs:
                   continue;
                 }
 
+                const isBinary = patchlessPaths.has(normalizedPath);
+
+                if (isBinary) {
+                  // Binary files cannot have line-level comments; ignore any line info.
+                  if (c.line !== undefined && c.line !== null) {
+                    console.log(`Ignoring line number on binary file comment: ${normalizedPath}`);
+                  }
+                  if (c.start_line !== undefined && c.start_line !== null) {
+                    console.log(`Ignoring start_line on binary file comment: ${normalizedPath}`);
+                  }
+
+                  fileComments.push({
+                    path: normalizedPath,
+                    body: decodeNewlines(c.body),
+                  });
+                  continue;
+                }
+
+                // Text file: line is required.
                 const line = Number(c.line);
                 if (!Number.isInteger(line) || line <= 0) {
                   console.log('Skipping comment with invalid line:', c);
@@ -262,31 +288,52 @@ jobs:
 
               const hasSummary = summary.length > 0;
 
-              if (!hasSummary && comments.length === 0) {
+              if (!hasSummary && comments.length === 0 && fileComments.length === 0) {
                 console.log('No valid summary or inline comments found. Skipping review posting.');
                 return;
               }
 
-              const payload = {
-                owner,
-                repo,
-                pull_number: prNumber,
-                event: 'COMMENT',
-              };
+              // Post the main review with text-file inline comments.
+              if (hasSummary || comments.length > 0) {
+                const payload = {
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  event: 'COMMENT',
+                };
 
-              if (hasSummary) {
-                payload.body = summary;
-              } else {
-                payload.body = 'Automated review by Oz Agent';
+                if (hasSummary) {
+                  payload.body = summary;
+                } else {
+                  payload.body = 'Automated review by Oz Agent';
+                }
+
+                if (comments.length > 0) {
+                  payload.comments = comments;
+                }
+
+                await github.rest.pulls.createReview(payload);
+                console.log('Review posted successfully.');
               }
 
-              if (comments.length > 0) {
-                payload.comments = comments;
+              // Post binary-file comments separately as file-level review comments.
+              const commitId = context.payload.pull_request.head.sha;
+              for (const bc of fileComments) {
+                try {
+                  await github.rest.pulls.createReviewComment({
+                    owner,
+                    repo,
+                    pull_number: prNumber,
+                    commit_id: commitId,
+                    path: bc.path,
+                    body: bc.body,
+                    subject_type: 'file',
+                  });
+                  console.log(`Posted binary file comment on ${bc.path}`);
+                } catch (commentError) {
+                  console.error(`Failed to post binary file comment on ${bc.path}:`, commentError.message);
+                }
               }
-
-              await github.rest.pulls.createReview(payload);
-
-              console.log('Review posted successfully.');
 
             } catch (error) {
               console.error('Failed to post review:', error);


### PR DESCRIPTION
This amends the comment submission and diff formatting logic in the PR review workflow to handle binary files.

Today, if the agent tries to comment on a binary file, we'll generate a malformed request and GitHub will reject the entire review.

As far as I can tell from GitHub's API docs, they support file-level comments on binary files, but not line-level comments.
