### PR TITLE
Make PR review workflow incremental on updates

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -15,6 +15,7 @@ Review the current pull request and write the output to `review.json`.
 - The workflow provides an annotated diff in `pr_diff.txt`.
 - The workflow provides the PR description in `pr_description.txt`.
 - The workflow provides existing PR comments (if any) in `pr_comments.txt`.
+- The workflow prompt identifies whether this is a `full` or `incremental` review.
 - Focus on files and lines changed by this PR.
 - Do not post comments or reviews to GitHub directly.
 
@@ -37,6 +38,8 @@ The `pr_comments.txt` file will only exist if there were existing comments on th
 - Prioritize correctness, security, error handling, and meaningful performance issues.
 - Include style or nit comments only when you can provide a concrete suggestion block.
 - If a concern involves untouched code, mention it in the summary instead of an inline comment.
+- For incremental reviews, review only the provided annotated diff since the last Oz review. Do not
+  repeat a high-level PR overview or restate findings from earlier comments.
 
 ## Binary Files
 
@@ -130,6 +133,9 @@ The `summary` must include:
 - Important concerns and any untouched-code concerns that could not be commented inline.
 - Issue counts in the format `Found: X critical, Y important, Z suggestions`.
 - A final recommendation of `Approve`, `Approve with nits`, or `Request changes`.
+
+For incremental reviews, leave `summary` as an empty string unless there is a new cross-file concern
+that cannot be expressed inline. Put new findings in `comments` whenever possible.
 
 ## Final Checks
 

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -39,6 +39,9 @@ on:
         required: true
 jobs:
   review_pr:
+    if:
+      github.event.action != 'review_requested' || github.event.requested_reviewer.login ==
+      'oz-agent'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,15 +50,99 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Checkout PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr checkout ${{ github.event.pull_request.number }}
           git fetch origin ${{ github.event.pull_request.base.ref }}
+      - name: Determine Review Scope
+        id: scope
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const headSha = pr.head.sha;
+            const baseSha = pr.base.sha;
+            const { execSync } = require('child_process');
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number: pr.number, per_page: 100 }
+            );
+
+            const markerPattern = /<!--\s*oz-agent-review:\s*(\{.*?\})\s*-->/s;
+            const botLogins = new Set(['github-actions[bot]', 'oz-agent']);
+            const newestFirst = reviews
+              .filter((review) => review.state !== 'PENDING')
+              .sort((a, b) => new Date(b.submitted_at || 0) - new Date(a.submitted_at || 0));
+
+            let lastReviewedSha = '';
+
+            for (const review of newestFirst) {
+              const body = review.body || '';
+              const marker = body.match(markerPattern);
+              if (!marker) continue;
+
+              try {
+                const metadata = JSON.parse(marker[1]);
+                if (metadata.head_sha && metadata.head_sha !== headSha) {
+                  lastReviewedSha = metadata.head_sha;
+                  break;
+                }
+              } catch (error) {
+                core.warning(`Ignoring invalid Oz review marker on review ${review.id}: ${error.message}`);
+              }
+            }
+
+            // Backward-compatible fallback for reviews posted before this workflow
+            // started adding Oz markers.
+            if (!lastReviewedSha) {
+              const previousBotReview = newestFirst.find(
+                (review) =>
+                  review.commit_id &&
+                  review.commit_id !== headSha &&
+                  botLogins.has(review.user?.login)
+              );
+              if (previousBotReview) {
+                lastReviewedSha = previousBotReview.commit_id;
+              }
+            }
+
+            if (lastReviewedSha) {
+              try {
+                execSync(`git merge-base --is-ancestor ${lastReviewedSha} HEAD`);
+              } catch (error) {
+                core.warning(
+                  `Previous Oz review commit ${lastReviewedSha} is not an ancestor of HEAD. Falling back to a full PR review.`
+                );
+                lastReviewedSha = '';
+              }
+            }
+
+            const reviewMode = lastReviewedSha ? 'incremental' : 'full';
+            core.setOutput('base_sha', lastReviewedSha || baseSha);
+            core.setOutput('last_reviewed_sha', lastReviewedSha);
+            core.setOutput('review_mode', reviewMode);
+            core.notice(
+              reviewMode === 'incremental'
+                ? `Reviewing changes since previous Oz review at ${lastReviewedSha}.`
+                : `No previous Oz review found. Reviewing full PR diff from ${baseSha}.`
+            );
+      - name: Build Annotated Diff
+        run: |
+          BASE_SHA="${{ steps.scope.outputs.base_sha }}"
+          if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "$BASE_SHA"
+          fi
+
           # Diff only the changes introduced in this PR, relative to the PR's base commit
+          # On follow-up reviews, BASE_SHA is the head commit from the last Oz review.
           # Add line numbers to each line: OLD_LINE NEW_LINE for context, OLD_LINE for deletions, NEW_LINE for additions
-          git diff ${{ github.event.pull_request.base.sha }}...HEAD | awk '
+          git diff "$BASE_SHA"...HEAD | awk '
             /^diff --git/ { print; next }
             /^index / { print; next }
             /^---/ { print; next }
@@ -142,11 +229,14 @@ jobs:
             const prompt = `Review Pull Request #${prNumber}.
 
             PR title: ${pr.title}
+            Review mode: ${{ steps.scope.outputs.review_mode }}
+            Last reviewed commit: ${{ steps.scope.outputs.last_reviewed_sha || 'none' }}
             PR description: Read \`${descriptionPath}\`
             Annotated diff: Read \`${diffPath}\`
             Existing PR comments: Read \`${commentsPath}\`
 
-            Use the review skill instructions as the base behavior. Apply them to this PR only.`;
+            Use the review skill instructions as the base behavior. Apply them to this PR only.
+            If review mode is incremental, review only the annotated diff since the last reviewed commit. Do not repeat a full PR overview or restate findings from existing PR comments. Leave summary empty unless there is a new cross-file concern that cannot be expressed inline.`;
 
             core.setOutput('prompt', prompt);
       - name: Run Oz Agent Review
@@ -169,6 +259,14 @@ jobs:
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
+            const reviewMode = '${{ steps.scope.outputs.review_mode }}';
+            const reviewBaseSha = '${{ steps.scope.outputs.base_sha }}';
+            const reviewHeadSha = context.payload.pull_request.head.sha;
+            const reviewMarker = `<!-- oz-agent-review: ${JSON.stringify({
+              head_sha: reviewHeadSha,
+              base_sha: reviewBaseSha,
+              mode: reviewMode,
+            })} -->`;
 
             try {
               if (!fs.existsSync('review.json')) {
@@ -297,18 +395,28 @@ jobs:
                 comments.push(commentPayload);
               }
 
-              const summary =
+              let summary =
                 typeof review.summary === 'string' ? decodeNewlines(review.summary).trim() : '';
+              if (reviewMode === 'incremental') {
+                summary = '';
+              }
 
               const hasSummary = summary.length > 0;
 
               if (!hasSummary && comments.length === 0 && fileComments.length === 0) {
-                console.log('No valid summary or inline comments found. Skipping review posting.');
+                await github.rest.pulls.createReview({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  event: 'COMMENT',
+                  body: reviewMarker,
+                });
+                console.log('No valid summary or inline comments found. Posted hidden Oz review marker.');
                 return;
               }
 
               // Post the main review with text-file inline comments.
-              if (hasSummary || comments.length > 0) {
+              if (hasSummary || comments.length > 0 || fileComments.length > 0) {
                 const payload = {
                   owner,
                   repo,
@@ -317,9 +425,11 @@ jobs:
                 };
 
                 if (hasSummary) {
-                  payload.body = summary;
+                  payload.body = `${summary}\n\n${reviewMarker}`;
+                } else if (reviewMode === 'incremental') {
+                  payload.body = reviewMarker;
                 } else {
-                  payload.body = 'Automated review by Oz Agent';
+                  payload.body = `Automated review by Oz Agent\n\n${reviewMarker}`;
                 }
 
                 if (comments.length > 0) {

--- a/README.md
+++ b/README.md
@@ -130,20 +130,27 @@ _Full Example_: [examples/review-pr.yml](examples/review-pr.yml)
 
 _Consumer Template_: [consumer-workflows/review-pr.yml](consumer-workflows/review-pr.yml)
 
-**Usage:** Runs automatically when a Pull Request is opened or marked ready for review.
+**Usage:** Runs automatically when a Pull Request is opened, marked ready for review, or updated. It
+can also run through GitHub's native review-request flow when the `oz-agent` GitHub user is
+requested as a reviewer.
 
-**Description:** Analyzes the diff of the PR and provides code review feedback.
+**Description:** Analyzes the diff of the PR and provides code review feedback. The first run
+reviews the full PR diff. Follow-up runs review only the commits added since the last Oz review and
+avoid reposting the full PR overview.
 
 **Setup:**
 
 - Ensure `WARP_API_KEY` is set in Repository Secrets.
 - The Agent needs read access to contents and write access to pull-requests.
+- To request a review from Oz like a person, invite the `oz-agent` GitHub user to private
+  organizations before using GitHub's **Request review** UI.
 
 **Expected Output:**
 
 - Inline comments on the PR diff highlighting potential bugs, security issues, or style
   improvements.
-- A general summary comment if applicable.
+- A general summary comment on the first review if applicable.
+- Incremental follow-up reviews that focus on newly pushed commits.
 
 **When to use:** Get immediate feedback on code changes before human review.
 

--- a/consumer-workflows/review-pr.yml
+++ b/consumer-workflows/review-pr.yml
@@ -7,8 +7,9 @@
 # Workflow: Auto PR Review
 # ======================================================================================
 # Usage:
-#   - Runs automatically when a Pull Request is opened or marked ready for review.
-#   - Analyzes the diff of the PR.
+#   - Runs automatically when a Pull Request is opened, marked ready for review, or updated.
+#   - Runs when the oz-agent GitHub user is requested as a reviewer.
+#   - Analyzes the full PR diff on the first review, then only the commits added since the last Oz review.
 #
 # Setup:
 #   - Ensure WARP_API_KEY is set in Repository Secrets.
@@ -16,7 +17,8 @@
 #
 # Expected Output:
 #   - Inline comments on the PR diff highlighting potential bugs, security issues, or style improvements.
-#   - A general summary comment if applicable.
+#   - A general summary comment on the first review if applicable.
+#   - Incremental follow-up reviews without repeating the full PR overview.
 #
 # When to use:
 #   - Use this to get immediate feedback on code changes before human review.
@@ -27,6 +29,8 @@ on:
     types:
       - opened
       - ready_for_review
+      - synchronize
+      - review_requested
 jobs:
   review_pr:
     uses: warpdotdev/oz-agent-action/.github/workflows/review-pr.yml@v1

--- a/examples/review-pr.yml
+++ b/examples/review-pr.yml
@@ -2,8 +2,9 @@
 # Workflow: Auto PR Review
 # ======================================================================================
 # Usage:
-#   - Runs automatically when a Pull Request is opened or marked ready for review.
-#   - Analyzes the diff of the PR.
+#   - Runs automatically when a Pull Request is opened, marked ready for review, or updated.
+#   - Runs when the oz-agent GitHub user is requested as a reviewer.
+#   - Analyzes the full PR diff on the first review, then only the commits added since the last Oz review.
 #
 # Setup:
 #   - Ensure WARP_API_KEY is set in Repository Secrets.
@@ -11,7 +12,8 @@
 #
 # Expected Output:
 #   - Inline comments on the PR diff highlighting potential bugs, security issues, or style improvements.
-#   - A general summary comment if applicable.
+#   - A general summary comment on the first review if applicable.
+#   - Incremental follow-up reviews without repeating the full PR overview.
 #
 # When to use:
 #   - Use this to get immediate feedback on code changes before human review.
@@ -20,10 +22,15 @@ name: Auto PR Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize, review_requested]
 
 jobs:
   review_pr:
+    # GitHub's native "request review" flow can trigger this workflow when the
+    # oz-agent GitHub user is requested. Other pull_request actions still run normally.
+    if:
+      github.event.action != 'review_requested' || github.event.requested_reviewer.login ==
+      'oz-agent'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,6 +39,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Checkout PR
         env:
@@ -39,9 +48,93 @@ jobs:
         run: |
           gh pr checkout ${{ github.event.pull_request.number }}
           git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Determine Review Scope
+        id: scope
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const headSha = pr.head.sha;
+            const baseSha = pr.base.sha;
+            const { execSync } = require('child_process');
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number: pr.number, per_page: 100 }
+            );
+
+            const markerPattern = /<!--\s*oz-agent-review:\s*(\{.*?\})\s*-->/s;
+            const botLogins = new Set(['github-actions[bot]', 'oz-agent']);
+            const newestFirst = reviews
+              .filter((review) => review.state !== 'PENDING')
+              .sort((a, b) => new Date(b.submitted_at || 0) - new Date(a.submitted_at || 0));
+
+            let lastReviewedSha = '';
+
+            for (const review of newestFirst) {
+              const body = review.body || '';
+              const marker = body.match(markerPattern);
+              if (!marker) continue;
+
+              try {
+                const metadata = JSON.parse(marker[1]);
+                if (metadata.head_sha && metadata.head_sha !== headSha) {
+                  lastReviewedSha = metadata.head_sha;
+                  break;
+                }
+              } catch (error) {
+                core.warning(`Ignoring invalid Oz review marker on review ${review.id}: ${error.message}`);
+              }
+            }
+
+            // Backward-compatible fallback for reviews posted before this workflow
+            // started adding Oz markers.
+            if (!lastReviewedSha) {
+              const previousBotReview = newestFirst.find(
+                (review) =>
+                  review.commit_id &&
+                  review.commit_id !== headSha &&
+                  botLogins.has(review.user?.login)
+              );
+              if (previousBotReview) {
+                lastReviewedSha = previousBotReview.commit_id;
+              }
+            }
+
+            if (lastReviewedSha) {
+              try {
+                execSync(`git merge-base --is-ancestor ${lastReviewedSha} HEAD`);
+              } catch (error) {
+                core.warning(
+                  `Previous Oz review commit ${lastReviewedSha} is not an ancestor of HEAD. Falling back to a full PR review.`
+                );
+                lastReviewedSha = '';
+              }
+            }
+
+            const reviewMode = lastReviewedSha ? 'incremental' : 'full';
+            core.setOutput('base_sha', lastReviewedSha || baseSha);
+            core.setOutput('last_reviewed_sha', lastReviewedSha);
+            core.setOutput('review_mode', reviewMode);
+            core.notice(
+              reviewMode === 'incremental'
+                ? `Reviewing changes since previous Oz review at ${lastReviewedSha}.`
+                : `No previous Oz review found. Reviewing full PR diff from ${baseSha}.`
+            );
+
+      - name: Build Annotated Diff
+        run: |
+          BASE_SHA="${{ steps.scope.outputs.base_sha }}"
+          if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "$BASE_SHA"
+          fi
+
           # Diff only the changes introduced in this PR, relative to the PR's base commit
+          # On follow-up reviews, BASE_SHA is the head commit from the last Oz review.
           # Add line numbers to each line: OLD_LINE NEW_LINE for context, OLD_LINE for deletions, NEW_LINE for additions
-          git diff ${{ github.event.pull_request.base.sha }}...HEAD | awk '
+          git diff "$BASE_SHA"...HEAD | awk '
             /^diff --git/ { print; next }
             /^index / { print; next }
             /^---/ { print; next }
@@ -129,11 +222,14 @@ jobs:
             const prompt = `Review Pull Request #${prNumber}.
 
             PR title: ${pr.title}
+            Review mode: ${{ steps.scope.outputs.review_mode }}
+            Last reviewed commit: ${{ steps.scope.outputs.last_reviewed_sha || 'none' }}
             PR description: Read \`${descriptionPath}\`
             Annotated diff: Read \`${diffPath}\`
             Existing PR comments: Read \`${commentsPath}\`
 
-            Use the review skill instructions as the base behavior. Apply them to this PR only.`;
+            Use the review skill instructions as the base behavior. Apply them to this PR only.
+            If review mode is incremental, review only the annotated diff since the last reviewed commit. Do not repeat a full PR overview or restate findings from existing PR comments. Leave summary empty unless there is a new cross-file concern that cannot be expressed inline.`;
 
             core.setOutput('prompt', prompt);
 
@@ -155,6 +251,14 @@ jobs:
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
+            const reviewMode = '${{ steps.scope.outputs.review_mode }}';
+            const reviewBaseSha = '${{ steps.scope.outputs.base_sha }}';
+            const reviewHeadSha = context.payload.pull_request.head.sha;
+            const reviewMarker = `<!-- oz-agent-review: ${JSON.stringify({
+              head_sha: reviewHeadSha,
+              base_sha: reviewBaseSha,
+              mode: reviewMode,
+            })} -->`;
 
             try {
               if (!fs.existsSync('review.json')) {
@@ -283,18 +387,28 @@ jobs:
                 comments.push(commentPayload);
               }
 
-              const summary =
+              let summary =
                 typeof review.summary === 'string' ? decodeNewlines(review.summary).trim() : '';
+              if (reviewMode === 'incremental') {
+                summary = '';
+              }
 
               const hasSummary = summary.length > 0;
 
               if (!hasSummary && comments.length === 0 && fileComments.length === 0) {
-                console.log('No valid summary or inline comments found. Skipping review posting.');
+                await github.rest.pulls.createReview({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  event: 'COMMENT',
+                  body: reviewMarker,
+                });
+                console.log('No valid summary or inline comments found. Posted hidden Oz review marker.');
                 return;
               }
 
               // Post the main review with text-file inline comments.
-              if (hasSummary || comments.length > 0) {
+              if (hasSummary || comments.length > 0 || fileComments.length > 0) {
                 const payload = {
                   owner,
                   repo,
@@ -303,9 +417,11 @@ jobs:
                 };
 
                 if (hasSummary) {
-                  payload.body = summary;
+                  payload.body = `${summary}\n\n${reviewMarker}`;
+                } else if (reviewMode === 'incremental') {
+                  payload.body = reviewMarker;
                 } else {
-                  payload.body = 'Automated review by Oz Agent';
+                  payload.body = `Automated review by Oz Agent\n\n${reviewMarker}`;
                 }
 
                 if (comments.length > 0) {


### PR DESCRIPTION
## Summary
- Add synchronize and oz-agent review-request triggers to the PR review workflow
- Track the last Oz review commit with a hidden review marker and diff follow-up reviews from that commit
- Suppress repeated overview summaries during incremental reviews while still recording hidden no-finding markers
- Document the GitHub native request-review setup for the oz-agent user

## Testing
- npm run gen-workflows
- npm run format:check
- npm run lint
- npm run package
- git diff --check

Fixes REMOTE-1743

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
