### PR TITLE
feat: expose cloud and host in reusable workflows

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ''
+      cloud:
+        description: Run the agent as a cloud agent using `oz agent run-cloud`.
+        required: false
+        type: boolean
+        default: false
+      host:
+        description: Optional host to route the agent run to when cloud mode is enabled.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Oz API key used by the Oz Agent.
@@ -110,6 +120,8 @@ jobs:
           name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
           mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
           skill: ${{ inputs.skill || '' }}
+          cloud: ${{ inputs.cloud }}
+          host: ${{ inputs.host }}
       - name: Create PR and Comment
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/daily-issue-summary.yml
+++ b/.github/workflows/daily-issue-summary.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ''
+      cloud:
+        description: Run the agent as a cloud agent using `oz agent run-cloud`.
+        required: false
+        type: boolean
+        default: false
+      host:
+        description: Optional host to route the agent run to when cloud mode is enabled.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Oz API key used by the Oz Agent.
@@ -135,6 +145,8 @@ jobs:
           name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
           mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
           skill: ${{ inputs.skill || '' }}
+          cloud: ${{ inputs.cloud }}
+          host: ${{ inputs.host }}
       - name: Post to Slack
         if: steps.fetch_issues.outputs.has_issues == 'true'
         env:

--- a/.github/workflows/fix-failing-checks.yml
+++ b/.github/workflows/fix-failing-checks.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ''
+      cloud:
+        description: Run the agent as a cloud agent using `oz agent run-cloud`.
+        required: false
+        type: boolean
+        default: false
+      host:
+        description: Optional host to route the agent run to when cloud mode is enabled.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Oz API key used by the Oz Agent.
@@ -148,6 +158,8 @@ jobs:
           name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
           mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
           skill: ${{ inputs.skill || '' }}
+          cloud: ${{ inputs.cloud }}
+          host: ${{ inputs.host }}
       - name: Create Fix PR
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/respond-to-comment.yml
+++ b/.github/workflows/respond-to-comment.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ''
+      cloud:
+        description: Run the agent as a cloud agent using `oz agent run-cloud`.
+        required: false
+        type: boolean
+        default: false
+      host:
+        description: Optional host to route the agent run to when cloud mode is enabled.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Oz API key used by the Oz Agent.
@@ -176,6 +186,8 @@ jobs:
           name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
           mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
           skill: ${{ inputs.skill || '' }}
+          cloud: ${{ inputs.cloud }}
+          host: ${{ inputs.host }}
       - name: Commit and Push Changes
         if: success()
         env:

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ''
+      cloud:
+        description: Run the agent as a cloud agent using `oz agent run-cloud`.
+        required: false
+        type: boolean
+        default: false
+      host:
+        description: Optional host to route the agent run to when cloud mode is enabled.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Oz API key used by the Oz Agent.
@@ -231,6 +241,8 @@ jobs:
           model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
           name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
           mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
+          cloud: ${{ inputs.cloud }}
+          host: ${{ inputs.host }}
       - name: Post Review
         uses: actions/github-script@v7
         if: always()

--- a/.github/workflows/suggest-review-fixes.yml
+++ b/.github/workflows/suggest-review-fixes.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ''
+      cloud:
+        description: Run the agent as a cloud agent using `oz agent run-cloud`.
+        required: false
+        type: boolean
+        default: false
+      host:
+        description: Optional host to route the agent run to when cloud mode is enabled.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Oz API key used by the Oz Agent.
@@ -132,6 +142,8 @@ jobs:
           name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
           mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
           skill: ${{ inputs.skill || '' }}
+          cloud: ${{ inputs.cloud }}
+          host: ${{ inputs.host }}
       - name: Validate responses.json
         run: |
           if [ -f responses.json ]; then

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ Then, add a step to your workflow that runs Oz:
     warp_api_key: ${{ secrets.WARP_API_KEY }}
 ```
 
+## Running in cloud mode
+
+By default, the action runs the agent on the GitHub Actions runner using `oz agent run`. Set
+`cloud: true` to start an Oz cloud agent using `oz agent run-cloud`:
+
+```yaml
+- name: Run Oz in cloud mode
+  uses: warpdotdev/oz-agent-action@v1
+  with:
+    prompt: Review the code changes on this branch
+    cloud: true
+    warp_api_key: ${{ secrets.WARP_API_KEY }}
+```
+
+Cloud runs use Warp-hosted workers by default. Set `host` only when routing a cloud run to a
+self-hosted worker.
+
 ## Using Skills
 
 Skills provide reusable, specialized capabilities for the Oz Agent. You can find a curated set of

--- a/consumer-workflows/auto-fix-issue.yml
+++ b/consumer-workflows/auto-fix-issue.yml
@@ -36,5 +36,7 @@ jobs:
       name: ''
       mcp: ''
       skill: ''
+      cloud: false
+      host: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/daily-issue-summary.yml
+++ b/consumer-workflows/daily-issue-summary.yml
@@ -35,6 +35,8 @@ jobs:
       name: ''
       mcp: ''
       skill: ''
+      cloud: false
+      host: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/consumer-workflows/fix-failing-checks.yml
+++ b/consumer-workflows/fix-failing-checks.yml
@@ -37,5 +37,7 @@ jobs:
       name: ''
       mcp: ''
       skill: ''
+      cloud: false
+      host: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/respond-to-comment.yml
+++ b/consumer-workflows/respond-to-comment.yml
@@ -38,5 +38,7 @@ jobs:
       name: ''
       mcp: ''
       skill: ''
+      cloud: false
+      host: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/review-pr.yml
+++ b/consumer-workflows/review-pr.yml
@@ -47,5 +47,7 @@ jobs:
       name: ''
       mcp: ''
       skill: ''
+      cloud: false
+      host: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/suggest-review-fixes.yml
+++ b/consumer-workflows/suggest-review-fixes.yml
@@ -34,5 +34,7 @@ jobs:
       name: ''
       mcp: ''
       skill: ''
+      cloud: false
+      host: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/scripts/build-workflows.mjs
+++ b/scripts/build-workflows.mjs
@@ -40,6 +40,18 @@ const defaultReusableWorkflowInputs = {
     description: 'Optional Oz skill identifier to use as the base prompt for the agent.',
     required: false,
     default: ''
+  },
+  cloud: {
+    description: 'Run the agent as a cloud agent using `oz agent run-cloud`.',
+    required: false,
+    type: 'boolean',
+    default: false
+  },
+  host: {
+    description: 'Optional host to route the agent run to when cloud mode is enabled.',
+    required: false,
+    type: 'string',
+    default: ''
   }
 }
 
@@ -165,7 +177,7 @@ function buildWorkflowCallInputs(inputsConfig) {
     const entry = {
       description: info.description ?? '',
       required: Boolean(info.required),
-      type: 'string'
+      type: info.type ?? 'string'
     }
     if (info.default !== undefined) {
       entry.default = info.default
@@ -227,6 +239,14 @@ function updateOzAgentActionInputs(job, workflowCallInputs) {
       step.with.skill = defaultSkill
         ? `\${{ inputs.skill || '${quoteGithubExpressionString(defaultSkill)}' }}`
         : "${{ inputs.skill || '' }}"
+    }
+
+    if ('cloud' in workflowCallInputs) {
+      step.with.cloud = '${{ inputs.cloud }}'
+    }
+
+    if ('host' in workflowCallInputs) {
+      step.with.host = '${{ inputs.host }}'
     }
   }
 }
@@ -354,7 +374,7 @@ async function generateConsumerTemplate(scenario, exampleYaml) {
   if (scenario.reusableWorkflow?.inputs) {
     for (const [inputName, inputConfig] of Object.entries(scenario.reusableWorkflow.inputs)) {
       if (!inputConfig.required) {
-        withBlock[inputName] = ''
+        withBlock[inputName] = inputConfig.default ?? ''
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow up to [#29](https://github.com/warpdotdev/oz-agent-action/pull/29), which added cloud-mode support to the core action, and [#31](https://github.com/warpdotdev/oz-agent-action/pull/31), which added host routing. This exposes both inputs through every reusable scenario workflow and consumer template so callers can configure them directly.

## Changes

- **`scripts/build-workflows.mjs`**: Added shared `cloud` and `host` reusable-workflow inputs, preserved their declared types and defaults during generation, and forwarded both values to each Oz action step.
- **`.github/workflows/`**: Regenerated all six reusable scenario workflows with a boolean `cloud` input, string `host` input, and direct action wiring.
- **`consumer-workflows/`**: Regenerated all six consumer templates with customizable `cloud: false` and `host: ''` values.
- **`README.md`**: Documented cloud-mode usage, including default Warp-hosted execution and optional self-hosted worker routing through `host`.

## Usage

```yaml
jobs:
  respond:
    uses: warpdotdev/oz-agent-action/.github/workflows/respond-to-comment.yml@v1
    with:
      cloud: true
      host: my-self-hosted-worker
    secrets:
      WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
```

Co-Authored-By: Oz <oz-agent@warp.dev>
